### PR TITLE
Adding support for Juju 2.x.  Breaking the plugin into 3 parts, the

### DIFF
--- a/sos/plugins/juju_controller.py
+++ b/sos/plugins/juju_controller.py
@@ -1,0 +1,193 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+# Copyright (C) 2019 Nick Niehoff <nick.niehoff@canonical.com>
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import re
+import os
+from sos.plugins import Plugin, UbuntuPlugin
+
+
+# A Juju Controller is a juju machine so this plugin assumes the juju_machine
+# plugin will be executed to collect that information
+class JujuController(Plugin, UbuntuPlugin):
+    """ Juju orchestration tool - Controller
+    """
+
+    plugin_name = "juju_controller"
+    profiles = ("virt", "sysmgmt")
+
+    # Use files instead of packages here because there is no package installed
+    #  on a juju controller that uniquely identifies it:
+    files = "/var/lib/juju/db"
+
+    option_list = [
+        (
+            "export-mongodb",
+            "Export mongodb collections as json files",
+            "",
+            False,
+        )
+    ]
+
+    def export_mongodb(self, machineid, dbpass):
+        collections = [
+            "actionnotifications",
+            "actions",
+            "annotations",
+            "applicationOfferConnections",
+            "applicationOffers",
+            "applications",
+            "bakeryStorageItems",
+            "blockdevices",
+            "charms",
+            "cleanups",
+            "cloudCredentials",
+            "cloudimagemetadata",
+            "clouds",
+            "constraints",
+            "containerRefs",
+            "controllers",
+            "controllerusers",
+            "deviceConstraints",
+            "endpointbindings",
+            "filesystems",
+            "generations",
+            "globalRefcounts",
+            "globalSettings",
+            "instanceData",
+            "ip.addresses",
+            "leaseholders",
+            "leases",
+            "linklayerdevices",
+            "linklayerdevicesrefs",
+            "machineUpgradeSeriesLocks",
+            "machineremovals",
+            "machines",
+            "managedStoredResources",
+            "meterStatus",
+            "metricsmanager",
+            "migrations",
+            "modelEntityRefs",
+            "modelUserLastConnection",
+            "models",
+            "modelusers",
+            "openedPorts",
+            "payloads",
+            "permissions",
+            "providerIDs",
+            "refcounts",
+            "relationNetworks",
+            "relations",
+            "relationscopes",
+            "remoteEntities",
+            "resources",
+            "sequence",
+            "settings",
+            "sshhostkeys",
+            "statuses",
+            "storageattachments",
+            "storageconstraints",
+            "storageinstances",
+            "storedResources",
+            "subnets",
+            "toolsmetadata",
+            "txns.prune",
+            "txns.stash",
+            "units",
+            "userLastLogin",
+            "usermodelname",
+            "users",
+            "volumes",
+        ]
+        # We don't collect txns.log, statuseshistory, metrics, txns due to size
+
+        for collection in collections:
+            filename = "mongoexport_collection_{}.json".format(collection)
+            # This will execute a mongoexport command, note it will add the
+            # password to the sos log
+            mongocmd = (
+                "mongoexport --host 127.0.0.1 --port 37017 --db juju "
+                + "--authenticationDatabase admin --ssl "
+                + "--sslAllowInvalidCertificates --username '{}' --password "
+                + "'{}' --collection {} --jsonArray"
+            )
+            self.add_cmd_output(
+                mongocmd.format(machineid, dbpass, collection),
+                suggest_filename=filename,
+            )
+
+    def get_machine_id(self):
+        # get the juju machine name machine-X
+        for dirpath, dirnames, filenames in os.walk("/var/lib/juju/agents"):
+            for dirname in dirnames:
+                match = re.match(r"(machine-\d+)", dirname)
+                if match:
+                    return match.group(1)
+        return None
+
+    def get_jujudb_pass(self, machineid):
+        # Get agent config and figure out password
+        try:
+            fp = open("/var/lib/juju/agents/" + machineid + "/agent.conf", "r")
+            filecontents = fp.read()
+            fp.close()
+        except Exception:
+            return None
+        for line in iter(filecontents.splitlines()):
+            match = re.match(r"^statepassword: (\S+)", line)
+            if match:
+                return match.group(1)
+        return None
+
+    def add_query(self, machineid, dbpass, queryname, query):
+        # Run a command for a single query
+        filename = "mongo_{}.json".format(queryname)
+        # This will execute a mongo command, note it will add the password to
+        # the sos log
+        mongocmd = (
+            "mongo 127.0.0.1:37017/juju --authenticationDatabase admin"
+            + " --ssl --sslAllowInvalidCertificates --quiet --username '{}' "
+            + "--password '{}' --eval '{}'"
+        )
+        self.add_cmd_output(
+            mongocmd.format(machineid, dbpass, query),
+            suggest_filename=filename,
+        )
+
+    def setup(self):
+        self.add_copy_spec("/etc/default/mongodb")
+        self.add_copy_spec("/var/lib/juju/bootstrap-params")
+        self.add_copy_spec("/lib/systemd/system/juju-db/juju-db.service")
+
+        # The key is the queryname to be used as the file name instead of the
+        # entire query
+        mongo_db_queries = {
+            "rs.status": "JSON.stringify(rs.status());",
+            "db.serverStatus": "JSON.stringify(db.serverStatus());",
+            "db.stats": "JSON.stringify(db.stats());",
+            "getCollectionInfos": "JSON.stringify(db.getCollectionInfos());",
+            "collections.stats": "stats = new Array(); "
+            + "db.getCollectionNames().forEach(function(coll) { "
+            + "var c = db.getCollection(coll); "
+            + "stats.push(JSON.stringify(c.stats())); "
+            + "}); "
+            + 'print("["); print(stats.join(",")); print("]")',
+        }
+
+        machineid = self.get_machine_id()
+        dbpass = self.get_jujudb_pass(machineid)
+
+        # If we got the password we can run some queries and export if needed
+        if dbpass:
+            for queryname, query in mongo_db_queries.items():
+                self.add_query(machineid, dbpass, queryname, query)
+            if self.get_option("export-mongodb"):
+                self.export_mongodb(machineid, dbpass)
+
+
+# vim: set et ts=4 sw=4 :

--- a/sos/plugins/juju_machine.py
+++ b/sos/plugins/juju_machine.py
@@ -1,0 +1,91 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+# Copyright (C) 2019 Nick Niehoff <nick.niehoff@canonical.com>
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+import os
+import re
+from sos.plugins import Plugin, UbuntuPlugin
+
+
+class JujuMachine(Plugin, UbuntuPlugin):
+    """ Juju orchestration tool - Machine
+    """
+
+    plugin_name = "juju_machine"
+    profiles = ("virt", "sysmgmt")
+
+    # Using files instead of packages here because there is no identifying
+    # package on a juju machine
+    files = ("/var/log/juju", "/usr/bin/juju-run")
+
+    def setup(self):
+        # Get juju services, they are uniquely named based on the deployment
+        # so we need to parse what their names are:
+        cmd = "systemctl --no-pager --all --no-legend list-units juju\\*"
+        juju_systemctl_output = self.call_ext_prog(cmd)["output"]
+        for line in iter(juju_systemctl_output.splitlines()):
+            match = re.match(r"^(juju\S+)\s.*", line)
+            if match:
+                self.add_journal(units=str(match.group(1)))
+
+        # Get agent configs for each agent
+        for dirpath, dirnames, filenames in os.walk("/var/lib/juju/agents"):
+            for dirname in dirnames:
+                self.add_copy_spec(
+                    "/var/lib/juju/agents/" + dirname + "/agent.conf"
+                )
+
+        self.add_cmd_output("ls -alRh /var/log/juju*")
+        self.add_cmd_output("ls -alRh /var/lib/juju*")
+        if self.get_option("all_logs"):
+            # /var/lib/juju used to be in the default capture moving here
+            # because it usually was way to big.  However, in most cases you
+            # want all logs you want this too.
+            self.add_copy_spec(["/var/log/juju", "/var/lib/juju"])
+        else:
+            # We need this because we want to collect to the limit of all
+            # *.logs in the directory.
+            if os.path.isdir("/var/log/juju/"):
+                for filename in os.listdir("/var/log/juju/"):
+                    if filename.endswith(".log"):
+                        fullname = os.path.join("/var/log/juju/" + filename)
+                        self.add_copy_spec(fullname)
+
+    def apply_regex_sub(self, regexp, subst):
+        self.do_path_regex_sub("/var/lib/juju/agents/*", regexp, subst)
+
+    def postproc(self):
+        protect_keys = [
+            "sharedsecret",
+            "apipassword",
+            "oldpassword",
+            "statepassword",
+        ]
+
+        protect_certs = [
+            "systemidentity",
+            "caprivatekey",
+            "controllerkey",
+            "controllercert",
+            "cacert",
+        ]
+
+        # Replace simple yamle sytle "key: value"
+        keys_regex = r"((?m)^\s*(%s)\s*:\s*)(.*)" % "|".join(protect_keys)
+        # Will match and replace a yaml multiline string that is a certificate
+        certs_regex = (
+            r"((?m)^\s*(%s)\s*:\s*)(\|\s*\n\s+-+BEGIN (.*)"
+            r"-+\s(\s+\S+\n)+\s+-+END )\4(-+)" % "|".join(protect_certs)
+        )
+        sub_regex = r"\1*********"
+
+        self.apply_regex_sub(keys_regex, sub_regex)
+        self.apply_regex_sub(certs_regex, sub_regex)
+
+
+# vim: set et ts=4 sw=4 :

--- a/sos/policies/debian.py
+++ b/sos/policies/debian.py
@@ -14,7 +14,7 @@ class DebianPolicy(LinuxPolicy):
     _debv_filter = ""
     valid_subclasses = [DebianPlugin]
     PATH = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games" \
-           + ":/usr/local/sbin:/usr/local/bin"
+        + ":/usr/local/sbin:/usr/local/bin:/snap/bin"
 
     def __init__(self, sysroot=None):
         super(DebianPolicy, self).__init__(sysroot=sysroot)


### PR DESCRIPTION
juju application (client), the juju machine, and the juju controller.
The juju client is specifically setup to run as a user and not as root,
however the problem is sosreport needs to be root.  To still be able to
run juju commands the juju plugin uses su to run the juju commands as
the specified user.  The juju machine plugin collect juju related logs
from a juju deployed machine.  The juju controller plugin collects
information specific to the juju mongodb.

Signed-off-by: Nick Niehoff nick.niehoff@canonical.com

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [] Is the subject and message clear and concise?
- [] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
